### PR TITLE
Fix linking issue with master branch of toolchain

### DIFF
--- a/src/asm/globals.asm
+++ b/src/asm/globals.asm
@@ -1,3 +1,4 @@
+	section	.text
 	public	__Z14in_degree_modev
 	public	__Z10get_fix_nrv
 	public	__Z7get_keyv


### PR DESCRIPTION
On the master branch of the toolchain, there's been a change to the linker that causes your symbols to have an address of 0 if you don't include a section directive, causing the program to crash immediately.